### PR TITLE
Fix enums and new in initializers as default values on PHP 8.1

### DIFF
--- a/src/ProxyManager/Factory/AbstractBaseFactory.php
+++ b/src/ProxyManager/Factory/AbstractBaseFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace ProxyManager\Factory;
 
-use Laminas\Code\Generator\ClassGenerator;
 use OutOfBoundsException;
 use ProxyManager\Configuration;
+use ProxyManager\Generator\ClassGenerator;
 use ProxyManager\ProxyGenerator\ProxyGeneratorInterface;
 use ProxyManager\Signature\Exception\InvalidSignatureException;
 use ProxyManager\Signature\Exception\MissingSignatureException;

--- a/src/ProxyManager/Generator/ClassGenerator.php
+++ b/src/ProxyManager/Generator/ClassGenerator.php
@@ -5,14 +5,48 @@ declare(strict_types=1);
 namespace ProxyManager\Generator;
 
 use Laminas\Code\Generator\ClassGenerator as LaminasClassGenerator;
+use ReflectionParameter;
+
+use function method_exists;
 
 /**
  * Class generator that ensures that interfaces/classes that are implemented/extended are FQCNs
  *
  * @internal do not use this in your code: it is only here for internal use
- * @deprecated this class was in use due to parent implementation not receiving prompt bugfixes, but
- *             `laminas/laminas-code` is actively maintained and receives quick release iterations.
  */
 class ClassGenerator extends LaminasClassGenerator
 {
+    public function generate(): string
+    {
+        $extendedClass = $this->getExtendedClass();
+
+        foreach ($this->getMethods() as $method) {
+            $class = $extendedClass;
+
+            if ($class === null) {
+                foreach ($this->getImplementedInterfaces() as $interface) {
+                    if (method_exists($interface, $method->getName())) {
+                        $class = $interface;
+                        break;
+                    }
+                }
+            }
+
+            if ($class === null || ! method_exists($class, $method->getName())) {
+                continue;
+            }
+
+            foreach ($method->getParameters() as $parameter) {
+                $default = $parameter->getDefaultValue();
+
+                if ($default === null) {
+                    continue;
+                }
+
+                $parameter->setDefaultValue(new ValueGenerator($default, new ReflectionParameter([$class, $method->getName()], $parameter->getName())));
+            }
+        }
+
+        return parent::generate();
+    }
 }

--- a/src/ProxyManager/Generator/ValueGenerator.php
+++ b/src/ProxyManager/Generator/ValueGenerator.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProxyManager\Generator;
+
+use Laminas\Code\Generator\Exception\RuntimeException;
+use Laminas\Code\Generator\ValueGenerator as LaminasValueGenerator;
+use ReflectionParameter;
+
+use function explode;
+use function implode;
+use function preg_replace;
+use function preg_split;
+use function rtrim;
+use function substr;
+use function var_export;
+
+use const PREG_SPLIT_DELIM_CAPTURE;
+
+/**
+ * @internal do not use this in your code: it is only here for internal use
+ */
+class ValueGenerator extends LaminasValueGenerator
+{
+    private $reflection;
+
+    public function __construct($value, ?ReflectionParameter $reflection = null)
+    {
+        if ($value instanceof LaminasValueGenerator) {
+            $this->value         = $value->value;
+            $this->type          = $value->type;
+            $this->arrayDepth    = $value->arrayDepth;
+            $this->outputMode    = $value->outputMode;
+            $this->allowedTypes  = $value->allowedTypes;
+            $this->constants     = $value->constants;
+            $this->isSourceDirty = $value->isSourceDirty;
+            $this->indentation   = $value->indentation;
+            $this->sourceContent = $value->sourceContent;
+        } else {
+            parent::__construct($value, parent::TYPE_AUTO, parent::OUTPUT_SINGLE_LINE);
+        }
+
+        $this->reflection = $reflection;
+    }
+
+    public function generate(): string
+    {
+        try {
+            return parent::generate();
+        } catch (RuntimeException $e) {
+            if ($this->reflection) {
+                $value = rtrim(substr(explode('$' . $this->reflection->getName() . ' = ', (string) $this->reflection, 2)[1], 0, -2));
+            } else {
+                $value = var_export($this->value, true);
+            }
+
+            return self::fixExport($value);
+        }
+    }
+
+    private static function fixExport(string $value): string
+    {
+        $parts = preg_split('{(\'(?:[^\'\\\\]*(?:\\\\.[^\'\\\\]*)*)\')}', $value, -1, PREG_SPLIT_DELIM_CAPTURE);
+
+        foreach ($parts as $i => &$part) {
+            if ($part === '' || $i % 2 !== 0) {
+                continue;
+            }
+
+            $part = preg_replace('/(?(DEFINE)(?<V>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+))(?<!\\\\)(?&V)(?:\\\\(?&V))*+::/', '\\\\$0', $part);
+        }
+
+        return implode('', $parts);
+    }
+}

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializer.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializer.php
@@ -8,6 +8,7 @@ use Laminas\Code\Generator\ParameterGenerator;
 use Laminas\Code\Generator\PropertyGenerator;
 use ProxyManager\Generator\MethodGenerator;
 use ProxyManager\Generator\Util\IdentifierSuffixer;
+use ProxyManager\Generator\ValueGenerator;
 use ProxyManager\ProxyGenerator\Util\Properties;
 use ReflectionProperty;
 
@@ -170,6 +171,6 @@ PHP;
         $name     = $property->getName();
         $defaults = $property->getDeclaringClass()->getDefaultProperties();
 
-        return var_export($defaults[$name] ?? null, true);
+        return (new ValueGenerator($defaults[$name] ?? null))->generate();
     }
 }

--- a/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace ProxyManagerTest\Functional;
 
-use Laminas\Code\Generator\ClassGenerator;
 use PHPUnit\Framework\TestCase;
 use ProxyManager\Exception\ExceptionInterface;
+use ProxyManager\Generator\ClassGenerator;
 use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;
 use ProxyManager\Proxy\ProxyInterface;
 use ProxyManager\ProxyGenerator\AccessInterceptorScopeLocalizerGenerator;

--- a/tests/ProxyManagerTest/Functional/MultipleProxyGenerationTest.php
+++ b/tests/ProxyManagerTest/Functional/MultipleProxyGenerationTest.php
@@ -22,6 +22,7 @@ use ProxyManagerTestAsset\ClassWithMixedReferenceableTypedProperties;
 use ProxyManagerTestAsset\ClassWithMixedTypedProperties;
 use ProxyManagerTestAsset\ClassWithParentHint;
 use ProxyManagerTestAsset\ClassWithPhp80TypedMethods;
+use ProxyManagerTestAsset\ClassWithPhp81Defaults;
 use ProxyManagerTestAsset\ClassWithPrivateProperties;
 use ProxyManagerTestAsset\ClassWithProtectedProperties;
 use ProxyManagerTestAsset\ClassWithPublicProperties;
@@ -136,6 +137,10 @@ final class MultipleProxyGenerationTest extends TestCase
 
         if (PHP_VERSION_ID >= 80000) {
             $objects[] = [new ClassWithPhp80TypedMethods()];
+        }
+
+        if (PHP_VERSION_ID >= 80100) {
+            $objects['php81defaults'] = [new ClassWithPhp81Defaults()];
         }
 
         return $objects;

--- a/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
@@ -18,12 +18,15 @@ use ProxyManagerTestAsset\ClassWithSelfHint;
 use ProxyManagerTestAsset\OtherObjectAccessClass;
 use ProxyManagerTestAsset\RemoteProxy\BazServiceInterface;
 use ProxyManagerTestAsset\RemoteProxy\Foo;
+use ProxyManagerTestAsset\RemoteProxy\FooEnum;
 use ProxyManagerTestAsset\RemoteProxy\FooServiceInterface;
 use ProxyManagerTestAsset\RemoteProxy\RemoteServiceWithDefaultsAndVariadicArguments;
 use ProxyManagerTestAsset\RemoteProxy\RemoteServiceWithDefaultsInterface;
+use ProxyManagerTestAsset\RemoteProxy\RemoteServiceWithPhp81DefaultsInterface;
 use ProxyManagerTestAsset\RemoteProxy\VariadicArgumentsServiceInterface;
 use ProxyManagerTestAsset\VoidCounter;
 use ReflectionClass;
+use stdClass;
 
 use function assert;
 use function get_class;
@@ -31,6 +34,8 @@ use function is_callable;
 use function random_int;
 use function ucfirst;
 use function uniqid;
+
+use const PHP_VERSION_ID;
 
 /**
  * Tests for {@see \ProxyManager\ProxyGenerator\RemoteObjectGenerator} produced objects
@@ -151,7 +156,7 @@ final class RemoteObjectFunctionalTest extends TestCase
     {
         $selfHintParam = new ClassWithSelfHint();
 
-        return [
+        $methods = [
             [
                 FooServiceInterface::class,
                 'foo',
@@ -273,6 +278,21 @@ final class RemoteObjectFunctionalTest extends TestCase
                 200,
             ],
         ];
+
+        if (PHP_VERSION_ID >= 80100) {
+            $methods['when using php8.1 defaults'] = [
+                RemoteServiceWithPhp81DefaultsInterface::class,
+                'php81Defaults',
+                [],
+                [
+                    FooEnum::bar,
+                    new stdClass(),
+                ],
+                200,
+            ];
+        }
+
+        return $methods;
     }
 
     /**

--- a/tests/ProxyManagerTest/GeneratorStrategy/BaseGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/BaseGeneratorStrategyTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace ProxyManagerTest\GeneratorStrategy;
 
-use Laminas\Code\Generator\ClassGenerator;
 use PHPUnit\Framework\TestCase;
+use ProxyManager\Generator\ClassGenerator;
 use ProxyManager\Generator\Util\UniqueIdentifierGenerator;
 use ProxyManager\GeneratorStrategy\BaseGeneratorStrategy;
 

--- a/tests/ProxyManagerTest/GeneratorStrategy/EvaluatingGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/EvaluatingGeneratorStrategyTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace ProxyManagerTest\GeneratorStrategy;
 
-use Laminas\Code\Generator\ClassGenerator;
 use PHPUnit\Framework\TestCase;
+use ProxyManager\Generator\ClassGenerator;
 use ProxyManager\Generator\Util\UniqueIdentifierGenerator;
 use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;
 

--- a/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace ProxyManagerTest\GeneratorStrategy;
 
-use Laminas\Code\Generator\ClassGenerator;
 use PHPUnit\Framework\TestCase;
 use ProxyManager\Exception\FileNotWritableException;
 use ProxyManager\FileLocator\FileLocatorInterface;
+use ProxyManager\Generator\ClassGenerator;
 use ProxyManager\Generator\Util\UniqueIdentifierGenerator;
 use ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy;
 

--- a/tests/ProxyManagerTest/ProxyGenerator/AbstractProxyGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AbstractProxyGeneratorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace ProxyManagerTest\ProxyGenerator;
 
-use Laminas\Code\Generator\ClassGenerator;
 use PHPUnit\Framework\TestCase;
+use ProxyManager\Generator\ClassGenerator;
 use ProxyManager\Generator\Util\UniqueIdentifierGenerator;
 use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;
 use ProxyManager\ProxyGenerator\ProxyGeneratorInterface;
@@ -18,6 +18,7 @@ use ProxyManagerTestAsset\ClassWithMixedProperties;
 use ProxyManagerTestAsset\ClassWithMixedReferenceableTypedProperties;
 use ProxyManagerTestAsset\ClassWithMixedTypedProperties;
 use ProxyManagerTestAsset\ClassWithPhp80TypedMethods;
+use ProxyManagerTestAsset\ClassWithPhp81Defaults;
 use ProxyManagerTestAsset\IterableMethodTypeHintedInterface;
 use ProxyManagerTestAsset\ObjectMethodTypeHintedInterface;
 use ProxyManagerTestAsset\ReturnTypeHintedClass;
@@ -110,6 +111,10 @@ abstract class AbstractProxyGeneratorTest extends TestCase
 
         if (PHP_VERSION_ID >= 80000) {
             $implementations[] = [ClassWithPhp80TypedMethods::class];
+        }
+
+        if (PHP_VERSION_ID >= 80100) {
+            $implementations['php81defaults'] = [ClassWithPhp81Defaults::class];
         }
 
         return $implementations;

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizerTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizerTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace ProxyManagerTest\ProxyGenerator;
 
-use Laminas\Code\Generator\ClassGenerator;
 use ProxyManager\Exception\InvalidProxiedClassException;
 use ProxyManager\Exception\UnsupportedProxiedClassException;
+use ProxyManager\Generator\ClassGenerator;
 use ProxyManager\Proxy\AccessInterceptorInterface;
 use ProxyManager\ProxyGenerator\AccessInterceptorScopeLocalizerGenerator;
 use ProxyManager\ProxyGenerator\ProxyGeneratorInterface;

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializerTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializerTest.php
@@ -116,98 +116,74 @@ if ($this->track || ! $this->init) {
 $this->track = true;
 
 $this->publicUnTypedProperty = 'publicUnTypedProperty';
-$this->publicUnTypedPropertyWithoutDefaultValue = NULL;
+$this->publicUnTypedPropertyWithoutDefaultValue = null;
 $this->publicBoolProperty = true;
 $this->publicNullableBoolProperty = true;
-$this->publicNullableBoolPropertyWithoutDefaultValue = NULL;
+$this->publicNullableBoolPropertyWithoutDefaultValue = null;
 $this->publicIntProperty = 123;
 $this->publicNullableIntProperty = 123;
-$this->publicNullableIntPropertyWithoutDefaultValue = NULL;
+$this->publicNullableIntPropertyWithoutDefaultValue = null;
 $this->publicFloatProperty = 123.456;
 $this->publicNullableFloatProperty = 123.456;
-$this->publicNullableFloatPropertyWithoutDefaultValue = NULL;
+$this->publicNullableFloatPropertyWithoutDefaultValue = null;
 $this->publicStringProperty = 'publicStringProperty';
 $this->publicNullableStringProperty = 'publicStringProperty';
-$this->publicNullableStringPropertyWithoutDefaultValue = NULL;
-$this->publicArrayProperty = array (
-  0 => 'publicArrayProperty',
-);
-$this->publicNullableArrayProperty = array (
-  0 => 'publicArrayProperty',
-);
-$this->publicNullableArrayPropertyWithoutDefaultValue = NULL;
-$this->publicIterableProperty = array (
-  0 => 'publicIterableProperty',
-);
-$this->publicNullableIterableProperty = array (
-  0 => 'publicIterableProperty',
-);
-$this->publicNullableIterablePropertyWithoutDefaultValue = NULL;
-$this->publicNullableObjectProperty = NULL;
-$this->publicNullableClassProperty = NULL;
+$this->publicNullableStringPropertyWithoutDefaultValue = null;
+$this->publicArrayProperty = ['publicArrayProperty'];
+$this->publicNullableArrayProperty = ['publicArrayProperty'];
+$this->publicNullableArrayPropertyWithoutDefaultValue = null;
+$this->publicIterableProperty = ['publicIterableProperty'];
+$this->publicNullableIterableProperty = ['publicIterableProperty'];
+$this->publicNullableIterablePropertyWithoutDefaultValue = null;
+$this->publicNullableObjectProperty = null;
+$this->publicNullableClassProperty = null;
 $this->protectedUnTypedProperty = 'protectedUnTypedProperty';
-$this->protectedUnTypedPropertyWithoutDefaultValue = NULL;
+$this->protectedUnTypedPropertyWithoutDefaultValue = null;
 $this->protectedBoolProperty = true;
 $this->protectedNullableBoolProperty = true;
-$this->protectedNullableBoolPropertyWithoutDefaultValue = NULL;
+$this->protectedNullableBoolPropertyWithoutDefaultValue = null;
 $this->protectedIntProperty = 123;
 $this->protectedNullableIntProperty = 123;
-$this->protectedNullableIntPropertyWithoutDefaultValue = NULL;
+$this->protectedNullableIntPropertyWithoutDefaultValue = null;
 $this->protectedFloatProperty = 123.456;
 $this->protectedNullableFloatProperty = 123.456;
-$this->protectedNullableFloatPropertyWithoutDefaultValue = NULL;
+$this->protectedNullableFloatPropertyWithoutDefaultValue = null;
 $this->protectedStringProperty = 'protectedStringProperty';
 $this->protectedNullableStringProperty = 'protectedStringProperty';
-$this->protectedNullableStringPropertyWithoutDefaultValue = NULL;
-$this->protectedArrayProperty = array (
-  0 => 'protectedArrayProperty',
-);
-$this->protectedNullableArrayProperty = array (
-  0 => 'protectedArrayProperty',
-);
-$this->protectedNullableArrayPropertyWithoutDefaultValue = NULL;
-$this->protectedIterableProperty = array (
-  0 => 'protectedIterableProperty',
-);
-$this->protectedNullableIterableProperty = array (
-  0 => 'protectedIterableProperty',
-);
-$this->protectedNullableIterablePropertyWithoutDefaultValue = NULL;
-$this->protectedNullableObjectProperty = NULL;
-$this->protectedNullableClassProperty = NULL;
+$this->protectedNullableStringPropertyWithoutDefaultValue = null;
+$this->protectedArrayProperty = ['protectedArrayProperty'];
+$this->protectedNullableArrayProperty = ['protectedArrayProperty'];
+$this->protectedNullableArrayPropertyWithoutDefaultValue = null;
+$this->protectedIterableProperty = ['protectedIterableProperty'];
+$this->protectedNullableIterableProperty = ['protectedIterableProperty'];
+$this->protectedNullableIterablePropertyWithoutDefaultValue = null;
+$this->protectedNullableObjectProperty = null;
+$this->protectedNullableClassProperty = null;
 static $cacheProxyManagerTestAsset_ClassWithMixedTypedProperties;
 
 $cacheProxyManagerTestAsset_ClassWithMixedTypedProperties ?? $cacheProxyManagerTestAsset_ClassWithMixedTypedProperties = \Closure::bind(static function ($instance) {
     $instance->privateUnTypedProperty = 'privateUnTypedProperty';
-    $instance->privateUnTypedPropertyWithoutDefaultValue = NULL;
+    $instance->privateUnTypedPropertyWithoutDefaultValue = null;
     $instance->privateBoolProperty = true;
     $instance->privateNullableBoolProperty = true;
-    $instance->privateNullableBoolPropertyWithoutDefaultValue = NULL;
+    $instance->privateNullableBoolPropertyWithoutDefaultValue = null;
     $instance->privateIntProperty = 123;
     $instance->privateNullableIntProperty = 123;
-    $instance->privateNullableIntPropertyWithoutDefaultValue = NULL;
+    $instance->privateNullableIntPropertyWithoutDefaultValue = null;
     $instance->privateFloatProperty = 123.456;
     $instance->privateNullableFloatProperty = 123.456;
-    $instance->privateNullableFloatPropertyWithoutDefaultValue = NULL;
+    $instance->privateNullableFloatPropertyWithoutDefaultValue = null;
     $instance->privateStringProperty = 'privateStringProperty';
     $instance->privateNullableStringProperty = 'privateStringProperty';
-    $instance->privateNullableStringPropertyWithoutDefaultValue = NULL;
-    $instance->privateArrayProperty = array (
-  0 => 'privateArrayProperty',
-);
-    $instance->privateNullableArrayProperty = array (
-  0 => 'privateArrayProperty',
-);
-    $instance->privateNullableArrayPropertyWithoutDefaultValue = NULL;
-    $instance->privateIterableProperty = array (
-  0 => 'privateIterableProperty',
-);
-    $instance->privateNullableIterableProperty = array (
-  0 => 'privateIterableProperty',
-);
-    $instance->privateNullableIterablePropertyWithoutDefaultValue = NULL;
-    $instance->privateNullableObjectProperty = NULL;
-    $instance->privateNullableClassProperty = NULL;
+    $instance->privateNullableStringPropertyWithoutDefaultValue = null;
+    $instance->privateArrayProperty = ['privateArrayProperty'];
+    $instance->privateNullableArrayProperty = ['privateArrayProperty'];
+    $instance->privateNullableArrayPropertyWithoutDefaultValue = null;
+    $instance->privateIterableProperty = ['privateIterableProperty'];
+    $instance->privateNullableIterableProperty = ['privateIterableProperty'];
+    $instance->privateNullableIterablePropertyWithoutDefaultValue = null;
+    $instance->privateNullableObjectProperty = null;
+    $instance->privateNullableClassProperty = null;
 }, null, 'ProxyManagerTestAsset\\ClassWithMixedTypedProperties');
 
 $cacheProxyManagerTestAsset_ClassWithMixedTypedProperties($this);

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhostGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhostGeneratorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace ProxyManagerTest\ProxyGenerator;
 
-use Laminas\Code\Generator\ClassGenerator;
 use ProxyManager\Exception\InvalidProxiedClassException;
+use ProxyManager\Generator\ClassGenerator;
 use ProxyManager\Proxy\GhostObjectInterface;
 use ProxyManager\ProxyGenerator\LazyLoadingGhostGenerator;
 use ProxyManager\ProxyGenerator\ProxyGeneratorInterface;

--- a/tests/ProxyManagerTest/ProxyGenerator/NullObjectGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/NullObjectGeneratorTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ProxyManagerTest\ProxyGenerator;
 
-use Laminas\Code\Generator\ClassGenerator;
+use ProxyManager\Generator\ClassGenerator;
 use ProxyManager\Generator\Util\UniqueIdentifierGenerator;
 use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;
 use ProxyManager\Proxy\NullObjectInterface;
@@ -19,6 +19,7 @@ use ProxyManagerTestAsset\ClassWithMixedProperties;
 use ProxyManagerTestAsset\ClassWithMixedReferenceableTypedProperties;
 use ProxyManagerTestAsset\ClassWithMixedTypedProperties;
 use ProxyManagerTestAsset\ClassWithPhp80TypedMethods;
+use ProxyManagerTestAsset\ClassWithPhp81Defaults;
 use ReflectionClass;
 use ReflectionMethod;
 
@@ -129,6 +130,10 @@ final class NullObjectGeneratorTest extends AbstractProxyGeneratorTest
 
         if (PHP_VERSION_ID >= 80000) {
             $implementations[] = [ClassWithPhp80TypedMethods::class];
+        }
+
+        if (PHP_VERSION_ID >= 80100) {
+            $implementations[] = [ClassWithPhp81Defaults::class];
         }
 
         return $implementations;

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethodTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethodTest.php
@@ -40,13 +40,12 @@ final class RemoteObjectMethodTest extends TestCase
         self::assertSame('publicByReferenceParameterMethod', $method->getName());
         self::assertCount(2, $method->getParameters());
         self::assertSame(
-            '$defaultValues = array (
-  0 => NULL,
-  1 => NULL,
-);
-$declaredParameterCount = 2;
+            '$args = \func_get_args();
 
-$args = \func_get_args() + $defaultValues;
+switch (\func_num_args()) {
+    case 0: $args[] = null;
+    case 1: $args[] = null;
+}
 
 $return = $this->adapter->call(\'Laminas\\\\Code\\\\Generator\\\\PropertyGenerator\', \'publicByReferenceParameterMethod\', $args);
 
@@ -74,12 +73,11 @@ return $return;',
         self::assertSame('publicArrayHintedMethod', $method->getName());
         self::assertCount(1, $method->getParameters());
         self::assertSame(
-            "\$defaultValues = array (
-  0 => NULL,
-);
-\$declaredParameterCount = 1;
+            "\$args = \\func_get_args();
 
-\$args = \\func_get_args() + \$defaultValues;
+switch (\\func_num_args()) {
+    case 0: \$args[] = null;
+}
 
 \$return = \$this->adapter->call('Laminas\\\\Code\\\\Generator\\\\PropertyGenerator', 'publicArrayHintedMethod', \$args);
 
@@ -107,11 +105,10 @@ return \$return;",
         self::assertSame('publicMethod', $method->getName());
         self::assertCount(0, $method->getParameters());
         self::assertSame(
-            "\$defaultValues = array (
-);
-\$declaredParameterCount = 0;
+            "\$args = \\func_get_args();
 
-\$args = \\func_get_args() + \$defaultValues;
+switch (\\func_num_args()) {
+}
 
 \$return = \$this->adapter->call('Laminas\\\\Code\\\\Generator\\\\PropertyGenerator', 'publicMethod', \$args);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObjectGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObjectGeneratorTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ProxyManagerTest\ProxyGenerator;
 
-use Laminas\Code\Generator\ClassGenerator;
+use ProxyManager\Generator\ClassGenerator;
 use ProxyManager\Generator\Util\UniqueIdentifierGenerator;
 use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;
 use ProxyManager\Proxy\RemoteObjectInterface;
@@ -18,6 +18,7 @@ use ProxyManagerTestAsset\ClassWithMixedProperties;
 use ProxyManagerTestAsset\ClassWithMixedReferenceableTypedProperties;
 use ProxyManagerTestAsset\ClassWithMixedTypedProperties;
 use ProxyManagerTestAsset\ClassWithPhp80TypedMethods;
+use ProxyManagerTestAsset\ClassWithPhp81Defaults;
 use ReflectionClass;
 
 use function array_diff;
@@ -99,6 +100,10 @@ final class RemoteObjectGeneratorTest extends AbstractProxyGeneratorTest
 
         if (PHP_VERSION_ID >= 80000) {
             $implementations[] = [ClassWithPhp80TypedMethods::class];
+        }
+
+        if (PHP_VERSION_ID >= 80100) {
+            $implementations['php81defaults'] = [ClassWithPhp81Defaults::class];
         }
 
         return $implementations;

--- a/tests/ProxyManagerTestAsset/ClassWithPhp81Defaults.php
+++ b/tests/ProxyManagerTestAsset/ClassWithPhp81Defaults.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProxyManagerTestAsset;
+
+use stdClass;
+
+enum FooEnum
+{
+    case bar;
+}
+
+/**
+ * Base test class to play around with new default values that came with PHP 8.1.0
+ */
+class ClassWithPhp81Defaults
+{
+    public FooEnum $enum = FooEnum::bar;
+
+    public function __construct($enum = FooEnum::bar, $object = new stdClass())
+    {
+    }
+}

--- a/tests/ProxyManagerTestAsset/RemoteProxy/FooEnum.php
+++ b/tests/ProxyManagerTestAsset/RemoteProxy/FooEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProxyManagerTestAsset\RemoteProxy;
+
+enum FooEnum
+{
+    case bar;
+}

--- a/tests/ProxyManagerTestAsset/RemoteProxy/RemoteServiceWithPhp81DefaultsInterface.php
+++ b/tests/ProxyManagerTestAsset/RemoteProxy/RemoteServiceWithPhp81DefaultsInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProxyManagerTestAsset\RemoteProxy;
+
+use stdClass;
+
+/**
+ * Simple interface for a remote API that methods with default parameters that came with PHP 8.1.0
+ */
+interface RemoteServiceWithPhp81DefaultsInterface
+{
+    public function php81Defaults($enum = FooEnum::bar, $object = new stdClass());
+}


### PR DESCRIPTION
On the path to fixing https://github.com/Ocramius/ProxyManager/issues/754

Works around https://github.com/laminas/laminas-code/issues/104

Relies on https://github.com/php/php-src/pull/7540

~Blocked by https://github.com/php/php-src/issues/8444~

Submitted upstream as https://github.com/Ocramius/ProxyManager/pull/755