### PR TITLE
Add return type to __sleep() method for PHP 8.1

### DIFF
--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSleep.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSleep.php
@@ -27,6 +27,13 @@ class MagicSleep extends MagicMethodGenerator
 
         $initializer = $initializerProperty->getName();
         $valueHolder = $valueHolderProperty->getName();
+        $reflectionMethod = $originalClass->hasMethod('__sleep')
+            ? $originalClass->getMethod('__sleep')
+            : null;
+        
+        if (\PHP_VERSION_ID > 80100 && $reflectionMethod && $reflectionMethod->hasReturnType()) {
+            $this->setReturnType($reflectionMethod->getReturnType());
+        }
 
         $this->setBody(
             '$this->' . $initializer . ' && ($this->' . $initializer


### PR DESCRIPTION
When upgrading to symfony/cache 6.0.8 following error occurs `__sleep() must be compatible with Symfony\Component\Cache\Adapter\AbstractAdapter::__sleep(): array`. This is due to missing return type.