### PR TITLE
Fix assign cache 'this' context

### DIFF
--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializer.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializer.php
@@ -175,7 +175,7 @@ PHP;
                 . '$' . $cacheKey . ' ?? $' . $cacheKey
                 . " = \\Closure::bind(function (\$instance, array & \$properties) {\n"
                 . $this->generatePrivatePropertiesAssignmentsCode($classPrivateProperties)
-                . '}, $this, ' . var_export($className, true) . ");\n\n"
+                . '}, null, ' . var_export($className, true) . ");\n\n"
                 . '$' . $cacheKey . '($this, $properties);';
         }
 
@@ -232,10 +232,10 @@ PHP;
 
             foreach ($scopedProperties as $property) {
                 $propertyAlias = $property->getName() . ($property->isPrivate() ? '_on_' . str_replace('\\', '_', $property->getDeclaringClass()->getName()) : '');
-                $code[]        = sprintf('    isset($nonReferenceableProperties->%s) && $this->%s = $nonReferenceableProperties->%1$s;', $propertyAlias, $property->getName());
+                $code[]        = sprintf('    isset($nonReferenceableProperties->%s) && $instance->%s = $nonReferenceableProperties->%1$s;', $propertyAlias, $property->getName());
             }
 
-            $code[] = '}, $this, ' . var_export($className, true) . ");\n";
+            $code[] = '}, null, ' . var_export($className, true) . ");\n";
             $code[] = '$' . $cacheKey . '($this, $nonReferenceableProperties);';
         }
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializerTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializerTest.php
@@ -76,7 +76,7 @@ $cacheFetchProxyManagerTestAsset_ClassWithMixedProperties ?? $cacheFetchProxyMan
     $properties['' . "\0" . 'ProxyManagerTestAsset\\ClassWithMixedProperties' . "\0" . 'privateProperty0'] = & $instance->privateProperty0;
     $properties['' . "\0" . 'ProxyManagerTestAsset\\ClassWithMixedProperties' . "\0" . 'privateProperty1'] = & $instance->privateProperty1;
     $properties['' . "\0" . 'ProxyManagerTestAsset\\ClassWithMixedProperties' . "\0" . 'privateProperty2'] = & $instance->privateProperty2;
-}, $this, 'ProxyManagerTestAsset\\ClassWithMixedProperties');
+}, null, 'ProxyManagerTestAsset\\ClassWithMixedProperties');
 
 $cacheFetchProxyManagerTestAsset_ClassWithMixedProperties($this, $properties);
 
@@ -314,7 +314,7 @@ $cacheFetchProxyManagerTestAsset_ClassWithMixedTypedProperties ?? $cacheFetchPro
     $properties['' . "\0" . 'ProxyManagerTestAsset\\ClassWithMixedTypedProperties' . "\0" . 'privateNullableIterablePropertyWithoutDefaultValue'] = & $instance->privateNullableIterablePropertyWithoutDefaultValue;
     $properties['' . "\0" . 'ProxyManagerTestAsset\\ClassWithMixedTypedProperties' . "\0" . 'privateNullableObjectProperty'] = & $instance->privateNullableObjectProperty;
     $properties['' . "\0" . 'ProxyManagerTestAsset\\ClassWithMixedTypedProperties' . "\0" . 'privateNullableClassProperty'] = & $instance->privateNullableClassProperty;
-}, $this, 'ProxyManagerTestAsset\\ClassWithMixedTypedProperties');
+}, null, 'ProxyManagerTestAsset\\ClassWithMixedTypedProperties');
 
 $cacheFetchProxyManagerTestAsset_ClassWithMixedTypedProperties($this, $properties);
 
@@ -338,15 +338,15 @@ isset($nonReferenceableProperties->protectedClassProperty) && $this->protectedCl
 static $cacheAssignProxyManagerTestAsset_ClassWithMixedTypedProperties;
 
 $cacheAssignProxyManagerTestAsset_ClassWithMixedTypedProperties ?? $cacheAssignProxyManagerTestAsset_ClassWithMixedTypedProperties = \Closure::bind(function ($instance, $nonReferenceableProperties) {
-    isset($nonReferenceableProperties->privateBoolPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties) && $this->privateBoolPropertyWithoutDefaultValue = $nonReferenceableProperties->privateBoolPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties;
-    isset($nonReferenceableProperties->privateIntPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties) && $this->privateIntPropertyWithoutDefaultValue = $nonReferenceableProperties->privateIntPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties;
-    isset($nonReferenceableProperties->privateFloatPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties) && $this->privateFloatPropertyWithoutDefaultValue = $nonReferenceableProperties->privateFloatPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties;
-    isset($nonReferenceableProperties->privateStringPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties) && $this->privateStringPropertyWithoutDefaultValue = $nonReferenceableProperties->privateStringPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties;
-    isset($nonReferenceableProperties->privateArrayPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties) && $this->privateArrayPropertyWithoutDefaultValue = $nonReferenceableProperties->privateArrayPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties;
-    isset($nonReferenceableProperties->privateIterablePropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties) && $this->privateIterablePropertyWithoutDefaultValue = $nonReferenceableProperties->privateIterablePropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties;
-    isset($nonReferenceableProperties->privateObjectProperty_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties) && $this->privateObjectProperty = $nonReferenceableProperties->privateObjectProperty_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties;
-    isset($nonReferenceableProperties->privateClassProperty_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties) && $this->privateClassProperty = $nonReferenceableProperties->privateClassProperty_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties;
-}, $this, 'ProxyManagerTestAsset\\ClassWithMixedTypedProperties');
+    isset($nonReferenceableProperties->privateBoolPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties) && $instance->privateBoolPropertyWithoutDefaultValue = $nonReferenceableProperties->privateBoolPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties;
+    isset($nonReferenceableProperties->privateIntPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties) && $instance->privateIntPropertyWithoutDefaultValue = $nonReferenceableProperties->privateIntPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties;
+    isset($nonReferenceableProperties->privateFloatPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties) && $instance->privateFloatPropertyWithoutDefaultValue = $nonReferenceableProperties->privateFloatPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties;
+    isset($nonReferenceableProperties->privateStringPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties) && $instance->privateStringPropertyWithoutDefaultValue = $nonReferenceableProperties->privateStringPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties;
+    isset($nonReferenceableProperties->privateArrayPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties) && $instance->privateArrayPropertyWithoutDefaultValue = $nonReferenceableProperties->privateArrayPropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties;
+    isset($nonReferenceableProperties->privateIterablePropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties) && $instance->privateIterablePropertyWithoutDefaultValue = $nonReferenceableProperties->privateIterablePropertyWithoutDefaultValue_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties;
+    isset($nonReferenceableProperties->privateObjectProperty_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties) && $instance->privateObjectProperty = $nonReferenceableProperties->privateObjectProperty_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties;
+    isset($nonReferenceableProperties->privateClassProperty_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties) && $instance->privateClassProperty = $nonReferenceableProperties->privateClassProperty_on_ProxyManagerTestAsset_ClassWithMixedTypedProperties;
+}, null, 'ProxyManagerTestAsset\\ClassWithMixedTypedProperties');
 
 $cacheAssignProxyManagerTestAsset_ClassWithMixedTypedProperties($this, $nonReferenceableProperties);
 $this->track = false;
@@ -404,10 +404,10 @@ $result = $this->init->__invoke($this, $methodName, $parameters, $this->init, $p
 static $cacheAssignProxyManagerTestAsset_ClassWithReadOnlyProperties;
 
 $cacheAssignProxyManagerTestAsset_ClassWithReadOnlyProperties ?? $cacheAssignProxyManagerTestAsset_ClassWithReadOnlyProperties = \Closure::bind(function ($instance, $nonReferenceableProperties) {
-    isset($nonReferenceableProperties->property0) && $this->property0 = $nonReferenceableProperties->property0;
-    isset($nonReferenceableProperties->property1) && $this->property1 = $nonReferenceableProperties->property1;
-    isset($nonReferenceableProperties->property2_on_ProxyManagerTestAsset_ClassWithReadOnlyProperties) && $this->property2 = $nonReferenceableProperties->property2_on_ProxyManagerTestAsset_ClassWithReadOnlyProperties;
-}, $this, 'ProxyManagerTestAsset\\ClassWithReadOnlyProperties');
+    isset($nonReferenceableProperties->property0) && $instance->property0 = $nonReferenceableProperties->property0;
+    isset($nonReferenceableProperties->property1) && $instance->property1 = $nonReferenceableProperties->property1;
+    isset($nonReferenceableProperties->property2_on_ProxyManagerTestAsset_ClassWithReadOnlyProperties) && $instance->property2 = $nonReferenceableProperties->property2_on_ProxyManagerTestAsset_ClassWithReadOnlyProperties;
+}, null, 'ProxyManagerTestAsset\\ClassWithReadOnlyProperties');
 
 $cacheAssignProxyManagerTestAsset_ClassWithReadOnlyProperties($this, $nonReferenceableProperties);
 $this->track = false;


### PR DESCRIPTION
This PR resolves bug with '$this' context. For some reason after getting closure from static cacheAssign variable and calling accessor, `$this` context doesn't change. I assumed that reson is using $this in closure instead of $instance 

Part of proxy class code from callInitializer method
```php
private function callInitializer0dc81($methodName, array $parameters)
    {
// hidden lines of code
        static $cacheAssignFoo;

        $cacheAssignFoo ?? $cacheAssignFoo = \Closure::bind(function ($instance, $nonReferenceableProperties) { // $instance is not using anywhere
            isset($nonReferenceableProperties->id_on_Foo) && $this->id = $nonReferenceableProperties->id_on_Foo;
            isset($nonReferenceableProperties->name_on_Foo) && $this->name = $nonReferenceableProperties->name_on_Foo;
        }, $this, 'Foo');

        $cacheAssignFoo($this, $nonReferenceableProperties); // after calling cached closure we have $this context without $id and $name properties

// hidden lines of code
}
```

Code that reproduces this bug:

```php
<?php

declare(strict_types=1);

use ProxyManager\Factory\LazyLoadingGhostFactory;
use ProxyManager\Proxy\GhostObjectInterface;

require_once 'vendor/autoload.php';

class Foo
{
    private int $id;

    private string $name;

    public function __construct(int $id, string $name)
    {
        $this->id = $id;

        $this->name = $name;
    }

    public function getIt(): int
    {
        return $this->id;
    }

    public function setId(int $id): void
    {
        $this->id = $id;
    }

    public function getName(): string
    {
        return $this->name;
    }

    public function setName(string $name): void
    {
        $this->name = $name;
    }
}

$proxyFactory = new LazyLoadingGhostFactory();

function createInitializer(int $num)
{
    return function (
        GhostObjectInterface|Foo $proxy,
        string $method,
        array $parameters,
        ?Closure &$initializer,
        array $properties
    ) use ($num) {
        $initializer = null;

        $properties["\0".Foo::class."\0".'id'] = $num;
        $properties["\0".Foo::class."\0".'name'] = "Name_$num";

        return true;
    };
}

$foo1 = $proxyFactory->createProxy(Foo::class, createInitializer(1));

echo $foo1->getName().PHP_EOL;

$foo2 = $proxyFactory->createProxy(Foo::class, createInitializer(2));

echo $foo2->getName().PHP_EOL; // Fatal error: Uncaught Error: Cannot access uninitialized non-nullable property Foo::$name

```