### PR TITLE
Fix ValueGenerator on PHP 8.2

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -19,6 +19,7 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
         operating-system:
           - "ubuntu-latest"
 

--- a/src/ProxyManager/Generator/ValueGenerator.php
+++ b/src/ProxyManager/Generator/ValueGenerator.php
@@ -61,6 +61,10 @@ class ValueGenerator extends LaminasValueGenerator
 
     private static function fixExport(string $value): string
     {
+        if (\PHP_VERSION_ID >= 80200) {
+            return $value;
+        }
+
         $parts = preg_split('{(\'(?:[^\'\\\\]*(?:\\\\.[^\'\\\\]*)*)\')}', $value, -1, PREG_SPLIT_DELIM_CAPTURE);
 
         foreach ($parts as $i => &$part) {


### PR DESCRIPTION
Fixes #28 by adding a conditional PHP version check.

Other CI failures are not related to this issue and should be solved separately.