### PR TITLE
Fix error when proxying a method with a mixed argument with a null default value

### DIFF
--- a/src/ProxyManager/Generator/MethodGenerator.php
+++ b/src/ProxyManager/Generator/MethodGenerator.php
@@ -69,7 +69,7 @@ class MethodGenerator extends LaminasMethodGenerator
                 $parameter->setDefaultValue(new ValueGenerator($default, $reflectionParameter));
                 $type = $parameter->getType();
 
-                if ($default->getValue() === null && strpos($type ?? '?', '?') !== 0 && strpos($type, '|') === false) {
+                if ($default->getValue() === null && strpos($type ?? '?', '?') !== 0 && strpos($type, '|') === false && $type !== 'mixed') {
                     $parameter->setType('?' . $type);
                 }
             }

--- a/tests/ProxyManagerTest/Generator/MethodGeneratorTest.php
+++ b/tests/ProxyManagerTest/Generator/MethodGeneratorTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use ProxyManager\Generator\MethodGenerator;
 use ProxyManagerTestAsset\BaseClass;
 use ProxyManagerTestAsset\ClassWithAbstractPublicMethod;
+use ProxyManagerTestAsset\ClassWithNullDefaultMethodArguments;
 use ProxyManagerTestAsset\EmptyClass;
 use ProxyManagerTestAsset\ReturnTypeHintedClass;
 use ProxyManagerTestAsset\ScalarTypeHintedClass;
@@ -132,6 +133,27 @@ final class MethodGeneratorTest extends TestCase
             ['acceptBoolean', 'bool'],
             ['acceptFloat', 'float'],
         ];
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testGenerateMethodWithNullDefaultMixedArgument(): void
+    {
+        $method = MethodGenerator::fromReflectionWithoutBodyAndDocBlock(new MethodReflection(
+            ClassWithNullDefaultMethodArguments::class,
+            'acceptMixed'
+        ));
+
+        self::assertSame('acceptMixed', $method->getName());
+
+        $parameters = $method->getParameters();
+
+        self::assertCount(1, $parameters);
+
+        $param = $parameters['param'];
+
+        self::assertSame('mixed', $param->getType());
     }
 
     public function testGenerateMethodWithVoidReturnTypeHinting(): void

--- a/tests/ProxyManagerTestAsset/ClassWithNullDefaultMethodArguments.php
+++ b/tests/ProxyManagerTestAsset/ClassWithNullDefaultMethodArguments.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProxyManagerTestAsset;
+
+class ClassWithNullDefaultMethodArguments
+{
+    public function acceptMixed(mixed $param = null)
+    {
+        return $param;
+    }
+}


### PR DESCRIPTION
Without this change, trying to proxy a `Symfony\Component\Console\Command\Command` would result in an `InvalidArgumentException` `Type "mixed" cannot be nullable` from the Laminas code generator. This is because of the `addArgument` method of the `Command` class having a `mixed $default = null` parameter. The error can be seen as a regression in 1.0.17 caused by #37.