### PR TITLE
Enable support for `symfony/filesystem` 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php":                       ">=7.1",
         "laminas/laminas-code":      "~3.4.1|^4.0",
-        "symfony/filesystem":        "^4.4.17|^5.0|^6.0|^7.0"
+        "symfony/filesystem":        "^4.4.17|^5.0|^6.0|^7.0|^8.0"
     },
     "conflict": {
         "zendframework/zend-stdlib": "<3.2.1",


### PR DESCRIPTION
`symfony/filesystem` 7.4 and 8.0 are identical. https://github.com/symfony/filesystem/compare/7.4...8.0